### PR TITLE
moved to .net standard 2.0

### DIFF
--- a/src/MarkdownDeepNext.sln
+++ b/src/MarkdownDeepNext.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25123.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.27004.2005
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MarkdownDeepNextJs", "MarkdownDeepNextJs\MarkdownDeepNextJs.csproj", "{C4CDC5F9-2420-407A-AE81-E3626F3BB251}"
 EndProject
@@ -24,5 +24,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {407CA59A-454C-46E8-A4E2-1D5314BE7C2E}
 	EndGlobalSection
 EndGlobal

--- a/src/MarkdownDeepNext/Bootdown.cs
+++ b/src/MarkdownDeepNext/Bootdown.cs
@@ -412,7 +412,7 @@ namespace MarkdownDeep
             //Create an image object from the uploaded file
             try
             {
-                var img = System.Drawing.Image.FromFile(str);
+                var img = new ImageSharp.Image (str);
                 width = img.Width;
                 height = img.Height;
 

--- a/src/MarkdownDeepNext/MarkdownDeepNext.csproj
+++ b/src/MarkdownDeepNext/MarkdownDeepNext.csproj
@@ -1,66 +1,21 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{49DB3689-E221-481B-B574-DABD243167F0}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>MarkdownDeepNext</RootNamespace>
-    <AssemblyName>MarkdownDeepNext</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Abbreviation.cs" />
-    <Compile Include="Block.cs" />
-    <Compile Include="BlockProcessor.cs" />
-    <Compile Include="FootnoteReference.cs" />
-    <Compile Include="HtmlTag.cs" />
-    <Compile Include="LinkDefinition.cs" />
-    <Compile Include="LinkInfo.cs" />
-    <Compile Include="Bootdown.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SpanFormatter.cs" />
-    <Compile Include="StringScanner.cs" />
-    <Compile Include="TableSpec.cs" />
-    <Compile Include="Token.cs" />
-    <Compile Include="Utils.cs" />
-  </ItemGroup>
+
+
   <ItemGroup>
     <None Include="MarkdownDeepNext.nuspec" />
     <None Include="MarkdownDeepNext.Full.nuspec" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+
+
+  <ItemGroup>
+    <PackageReference Include="RevStackCore-ImageSharp" Version="0.9.0" />
+  </ItemGroup>
+
   <Target Name="PostBuildMacros">
     <GetAssemblyIdentity AssemblyFiles="$(TargetPath)">
       <Output TaskParameter="Assemblies" ItemName="Targets" />
@@ -69,17 +24,19 @@
       <VersionNumber Include="@(Targets->'%(Version)')" />
     </ItemGroup>
   </Target>
+  
   <PropertyGroup>
-    <PreBuildEvent>
-    </PreBuildEvent>
     <PostBuildEventDependsOn>
       $(PostBuildEventDependsOn);
       PostBuildMacros;
     </PostBuildEventDependsOn>
-    <PostBuildEvent>if $(ConfigurationName) == Release
-(
- $(SolutionDir)..\nuget\NuGet pack "$(ProjectDir)MarkdownDeepNext.nuspec" -o "$(SolutionDir)..\Output" -version @(VersionNumber)
- $(SolutionDir)..\nuget\NuGet pack "$(ProjectDir)MarkdownDeepNext.Full.nuspec" -o "$(SolutionDir)..\Output" -version @(VersionNumber)
-)</PostBuildEvent>
+    <PostBuildEvent>
+      if $(ConfigurationName) == Release
+      (
+      $(SolutionDir)..\nuget\NuGet pack "$(ProjectDir)MarkdownDeepNext.nuspec" -o "$(SolutionDir)..\Output" -version @(VersionNumber)
+      $(SolutionDir)..\nuget\NuGet pack "$(ProjectDir)MarkdownDeepNext.Full.nuspec" -o "$(SolutionDir)..\Output" -version @(VersionNumber)
+      )
+    </PostBuildEvent>
+
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Hello.
When I started to migrate my web app to ASP.NET Core 2.0 I couldn't add your lib to my project even in compatibility mode because markdowndeep uses **System.Drawing** namespace which is not implemented in.NET Standard yet.  So I fixed this problem deleting System.Drawing dependency and replaced it with RevStackCore-ImageSharp. And after that I was able to migrate target framework to .Net Standard 2.0 and use it in asp.net core apps
I think this can be usefull.
